### PR TITLE
Remove scrollbar when unnecessary

### DIFF
--- a/src/containers/UserPage/style.js
+++ b/src/containers/UserPage/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { CardBody } from 'reactstrap';
 
 export const CardBodyScroll = styled(CardBody)`
-    overflow-y: scroll;
+    overflow-y: auto;
 `;
 
 export const StyledCardBody = styled(CardBody)`


### PR DESCRIPTION
The scroll bar now only shows when content in CardBodyScroll is higher than container (this was an issue on Windows and Linux).